### PR TITLE
refactor logic

### DIFF
--- a/Lucid Weather Clock/ViewController.swift
+++ b/Lucid Weather Clock/ViewController.swift
@@ -63,11 +63,11 @@ class ViewController: UIViewController, BEMAnalogClockDelegate {
         chart.rotationEnabled = false
         chart.rotationAngle = 270.0
         
-        let tapGesture = UITapGestureRecognizer(target: self, action: Selector("debugInfo"))
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(ViewController.debugInfo))
         tapGesture.numberOfTapsRequired = 3
         view.addGestureRecognizer(tapGesture)
         
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: Selector("viewDidBecomeActive"), name: UIApplicationDidBecomeActiveNotification, object: nil)
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(ViewController.viewDidBecomeActive), name: UIApplicationDidBecomeActiveNotification, object: nil)
     }
 
     override func viewDidAppear(animated: Bool) {
@@ -99,7 +99,7 @@ class ViewController: UIViewController, BEMAnalogClockDelegate {
     }
     
     override func motionEnded(motion: UIEventSubtype, withEvent event: UIEvent?) {
-        guard let event = event where event.subtype = .MotionShake else { return }
+        guard let event = event where event.subtype == .MotionShake else { return }
         sharePrecipation()
     }
 
@@ -112,7 +112,7 @@ class ViewController: UIViewController, BEMAnalogClockDelegate {
     override func touchesBegan(touches: Set<UITouch>, withEvent event: UIEvent?) {
         if traitCollection.forceTouchCapability == UIForceTouchCapability.Unavailable {
             removeTimer()
-            timerLongPress = NSTimer.scheduledTimerWithTimeInterval(1.0, target: self, selector: Selector("showForecastHourly"), userInfo: nil, repeats: false)
+            timerLongPress = NSTimer.scheduledTimerWithTimeInterval(1.0, target: self, selector: #selector(ViewController.showForecastHourly), userInfo: nil, repeats: false)
         }
     }
     
@@ -183,7 +183,7 @@ class ViewController: UIViewController, BEMAnalogClockDelegate {
             clock.seconds = components.second
             clock.updateTimeAnimated(false)
 
-            self.performSelector(Selector("clockLoadingTick"), withObject: nil, afterDelay: 0.01)
+            self.performSelector(#selector(ViewController.clockLoadingTick), withObject: nil, afterDelay: 0.01)
         } else {
             clock.hours = 12
             clock.minutes = 0

--- a/Lucid Weather Clock/ViewController.swift
+++ b/Lucid Weather Clock/ViewController.swift
@@ -111,27 +111,16 @@ class ViewController: UIViewController, BEMAnalogClockDelegate {
     
     override func touchesBegan(touches: Set<UITouch>, withEvent event: UIEvent?) {
         if traitCollection.forceTouchCapability == UIForceTouchCapability.Unavailable {
-            if timerLongPress != nil {
-                timerLongPress.invalidate()
-                timerLongPress = nil
-            }
+            removeTimer()
             timerLongPress = NSTimer.scheduledTimerWithTimeInterval(1.0, target: self, selector: Selector("showForecastHourly"), userInfo: nil, repeats: false)
         }
     }
     
     override func touchesMoved(touches: Set<UITouch>, withEvent event: UIEvent?) {
         guard let touch = touches.first where traitCollection.forceTouchCapability == .Available else { return }
-        if touch.maximumPossibleForce / touch.force > 0.5 {
-            if !forceTouchActionActive {
-                forceTouchActionActive = true
-                showForecastHourly()
-            }
-        } else {
-            if forceTouchActionActive {
-                forceTouchActionActive = false
-                showForecastBest()
-            }
-        }
+        
+        forceTouchActionActive && touch.maximumPossibleForce / touch.force > 0.5 ? showForecastHourly() : showForecastBest()
+        forceTouchActionActive = !forceTouchActionActive
     }
     
     override func touchesCancelled(touches: Set<UITouch>?, withEvent event: UIEvent?) {
@@ -161,6 +150,7 @@ class ViewController: UIViewController, BEMAnalogClockDelegate {
     //MARK - Clock configuration
 
     func configureWatchface() {
+        // TODO abstract this into a separate file for styling the clock
         clock.enableShadows = true
         clock.faceBackgroundColor = UIColor.clearColor()
         clock.secondHandLength = 0.38 * clock.frame.width


### PR DESCRIPTION
The purpose of this PR is to reduce the size and complexity of the main view controller and start cleaning up some of the logic.  

Currently the main view controller is over 500 lines long.  It can be easy to get into the habit of creating extremely large view controllers to handle lots of logic but in the long run this can be detrimental b/c when working with a team, large files that multiple engineers are working on leads to conflict hell.  

Suggestions:
- break out the networking logic into their own files
- break out the location logic into their own files
- break out the view styling into their own files
- use guards and where to DRY up and reduce the lines of code, this PR has a few examples, in particular the touch logic
